### PR TITLE
将回复或@一类的消息格式，染色后呈现为@对应的玩家名称，并顺便修了一个bug

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -452,7 +452,7 @@ const deletePc = (index: number, i: CharItem) => {
   store.pcList.splice(index, 1);
     logMan.deleteByCharItem(i);
   }).catch(() => {
-    i.name = lastPCName;
+    // i.name = lastPCName;
   })
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -157,7 +157,7 @@ import previewTrg from "./components/previews/preview-trg.vue";
 import PreviewItem from './components/previews/preview-main-item.vue'
 import { LogItem, CharItem, packNameId } from "./logManager/types";
 import { setCharInfo } from './logManager/importers/_logImpoter'
-import { msgCommandFormat, msgImageFormat, msgIMUseridFormat, msgOffTopicFormat } from "./utils";
+import { msgCommandFormat, msgImageFormat, msgIMUseridFormat, msgOffTopicFormat, msgAtFormat } from "./utils";
 
 // 不用他了 虽然很不错，但是没有屏幕取色
 // import { ColorPicker } from 'vue-color-kit'
@@ -417,6 +417,7 @@ function showPreview() {
     msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice);
     msg = msgCommandFormat(msg, store.exportOptions);
     msg = msgIMUseridFormat(msg, store.exportOptions, i.isDice);
+    msg = msgAtFormat(msg, store.pcList);
     msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice); // 再过滤一次
     if (msg.trim() === '') continue;
 

--- a/src/components/previews/preview-bbs-item.vue
+++ b/src/components/previews/preview-bbs-item.vue
@@ -14,7 +14,7 @@ import dayjs from 'dayjs';
 import { computed } from 'vue';
 import { LogItem, packNameId } from '~/logManager/types';
 import { useStore } from '~/store';
-import { escapeHTML, msgCommandFormat, msgImageFormat, msgIMUseridFormat, msgOffTopicFormat } from '~/utils';
+import { escapeHTML, msgCommandFormat, msgImageFormat, msgIMUseridFormat, msgOffTopicFormat, msgAtFormat } from '~/utils';
 
 const store = useStore();
 
@@ -85,6 +85,7 @@ const bbsMessageSolve = (i: LogItem) => {
   msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice);
   msg = msgCommandFormat(msg, store.exportOptions);
   msg = msgIMUseridFormat(msg, store.exportOptions, i.isDice);
+  msg = msgAtFormat(msg, store.pcList);
   msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice); // 再过滤一次
 
   if (i.isDice) {

--- a/src/components/previews/preview-main-item.vue
+++ b/src/components/previews/preview-main-item.vue
@@ -12,7 +12,7 @@
 import dayjs from 'dayjs';
 import { LogItem, packNameId } from '~/logManager/types';
 import { useStore } from '~/store';
-import { escapeHTML, getCanvasFontSize, getTextWidth, msgCommandFormat, msgImageFormat, msgIMUseridFormat, msgOffTopicFormat } from '~/utils';
+import { escapeHTML, getCanvasFontSize, getTextWidth, msgCommandFormat, msgImageFormat, msgIMUseridFormat, msgOffTopicFormat, msgAtFormat } from '~/utils';
 
 const store = useStore();
 
@@ -76,6 +76,7 @@ const previewMessageSolve = (i: LogItem) => {
   msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice);
   msg = msgCommandFormat(msg, store.exportOptions);
   msg = msgIMUseridFormat(msg, store.exportOptions, i.isDice);
+  msg = msgAtFormat(msg, store.pcList);
   msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice); // 再过滤一次
 
   const prefix = (!store.exportOptions.timeHide ? `${timeSolve(i)}` : '') + nicknameSolve(i)

--- a/src/components/previews/preview-trg-item.vue
+++ b/src/components/previews/preview-trg-item.vue
@@ -15,7 +15,7 @@
 <script setup lang="ts">
 import { LogItem, packNameId } from '~/logManager/types';
 import { useStore } from '~/store';
-import { escapeHTML, msgCommandFormat, msgImageFormat, msgIMUseridFormat, msgOffTopicFormat } from '~/utils';
+import { escapeHTML, msgCommandFormat, msgImageFormat, msgIMUseridFormat, msgOffTopicFormat, msgAtFormat } from '~/utils';
 
 const store = useStore();
 
@@ -63,6 +63,7 @@ const trgMessageSolve = (i: LogItem) => {
   msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice);
   msg = msgCommandFormat(msg, store.exportOptions);
   msg = msgIMUseridFormat(msg, store.exportOptions, i.isDice);
+  msg = msgAtFormat(msg, store.pcList);
   msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice); // 再过滤一次
 
   let extra = ''


### PR DESCRIPTION
fix：删除角色操作，点击取消后，对应的角色名字会被清空

解决了 https://github.com/sealdice/story-painter/issues/15