### PR TITLE
fix：调整@消息格式函数的执行顺序，适配kook对应消息在开启“场外发言过滤”被吞的情况

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -414,10 +414,10 @@ function showPreview() {
     //   if (msg.trim() === '') continue;
     // }
     let msg = msgImageFormat(i.message, store.exportOptions);
+    msg = msgAtFormat(msg, store.pcList);
     msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice);
     msg = msgCommandFormat(msg, store.exportOptions);
     msg = msgIMUseridFormat(msg, store.exportOptions, i.isDice);
-    msg = msgAtFormat(msg, store.pcList);
     msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice); // 再过滤一次
     if (msg.trim() === '') continue;
 

--- a/src/components/previews/preview-bbs-item.vue
+++ b/src/components/previews/preview-bbs-item.vue
@@ -82,10 +82,10 @@ const bbsMessageSolve = (i: LogItem) => {
   if (store.pcMap.get(id)?.role === '隐藏') return '';
 
   let msg = msgImageFormat(escapeHTML(i.message), options);
+  msg = msgAtFormat(msg, store.pcList);
   msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice);
   msg = msgCommandFormat(msg, store.exportOptions);
   msg = msgIMUseridFormat(msg, store.exportOptions, i.isDice);
-  msg = msgAtFormat(msg, store.pcList);
   msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice); // 再过滤一次
 
   if (i.isDice) {

--- a/src/components/previews/preview-main-item.vue
+++ b/src/components/previews/preview-main-item.vue
@@ -73,10 +73,10 @@ const previewMessageSolve = (i: LogItem) => {
   if (store.pcMap.get(id)?.role === '隐藏') return '';
 
   let msg = msgImageFormat(escapeHTML(i.message), store.exportOptions, true);
+  msg = msgAtFormat(msg, store.pcList);
   msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice);
   msg = msgCommandFormat(msg, store.exportOptions);
   msg = msgIMUseridFormat(msg, store.exportOptions, i.isDice);
-  msg = msgAtFormat(msg, store.pcList);
   msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice); // 再过滤一次
 
   const prefix = (!store.exportOptions.timeHide ? `${timeSolve(i)}` : '') + nicknameSolve(i)

--- a/src/components/previews/preview-trg-item.vue
+++ b/src/components/previews/preview-trg-item.vue
@@ -60,10 +60,10 @@ const trgMessageSolve = (i: LogItem) => {
   if (store.pcMap.get(id)?.role === '隐藏') return '';
 
   let msg = msgImageFormat(escapeHTML(i.message), store.exportOptions, true);
+  msg = msgAtFormat(msg, store.pcList);
   msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice);
   msg = msgCommandFormat(msg, store.exportOptions);
   msg = msgIMUseridFormat(msg, store.exportOptions, i.isDice);
-  msg = msgAtFormat(msg, store.pcList);
   msg = msgOffTopicFormat(msg, store.exportOptions, i.isDice); // 再过滤一次
 
   let extra = ''


### PR DESCRIPTION
这里修了一个老bug，因为kook的@消息格式为`(met)1760369(met)`，所以会被当成...场外发言吞掉消息。

把处理@消息格式的函数优先级提升至场外发言过滤函数之上。

![image](https://github.com/sealdice/story-painter/assets/73411104/9819964b-9f45-4f41-9117-05ca05e334c4)
修复前：
![image](https://github.com/sealdice/story-painter/assets/73411104/6d5e5bd6-c699-492e-877b-e769b903075f)
修复后：
![image](https://github.com/sealdice/story-painter/assets/73411104/73acaff4-5593-4739-b652-7cdc4616ec0b)

