### PR TITLE
fix: 修复因用户昵称携带括号导致的染色错误

### DIFF
--- a/src/utils/highlight.ts
+++ b/src/utils/highlight.ts
@@ -10,8 +10,8 @@ import { completeFromList } from "@codemirror/autocomplete"
 import { CharItem } from "~/logManager/types"
 import { Extension } from "@codemirror/state";
 import * as twColors from 'tailwindcss/colors'
-
-export const reNameLine = /^([^(<\n]+)(\([^(\n]+\)|\<[^(\n]+\>)?(\s+)(\d{4}\/\d{1,2}\/\d{1,2} )?(\d{1,2}:\d{1,2}:\d{2})( #\d+)?/
+export const reNameLine = /^([^(<\n]+(\((?!\d+\))[^(\n]+\))?)(\(\d+\))?(\s+)(\d{4}\/\d{1,2}\/\d{1,2} )?(\d{1,2}:\d{1,2}:\d{2})( #\d+)?/
+// export const reNameLine = /^([^(<\n]+)(\([^(\n]+\)|\<[^(\n]+\>)?(\s+)(\d{4}\/\d{1,2}\/\d{1,2} )?(\d{1,2}:\d{1,2}:\d{2})( #\d+)?/
 export const reNameLine2 = /([^(<\n]+)(\([^(\n]+\)|\<[^(\n]+\>)?(\s+)(\d{4}\/\d{1,2}\/\d{1,2} )?(\d{1,2}:\d{1,2}:\d{2})( #\d+)?/g
 
 let nameReplace = (n: string) => {
@@ -47,7 +47,7 @@ export function generateLang(pcList: CharItem[], options: any = undefined): Exte
   const pcMap: { [name: string]: CharItem } = {}
 
   for (let i of pcList) {
-    i.name = i.name.replaceAll('(', '（').replaceAll(')', '）');
+    // i.name = i.name.replaceAll('(', '（').replaceAll(')', '）');
     const theName = nameReplace(i.name)
     const tag = Tag.define()
     const tag2 = Tag.define()


### PR DESCRIPTION
旧版本对于昵称带有括号的用户识别存在问题，会导致其用户名称和发言无法识别，被按照上一个发言人的发言进行染色。
现修改对应的正则并删除部分语句，如果存在问题请指出原语句的适配场景